### PR TITLE
Avoid parsing exception from ZonedDateTimes with missing milliseconds  

### DIFF
--- a/src/ToStruct.jl
+++ b/src/ToStruct.jl
@@ -1,4 +1,5 @@
 module ToStruct
+using TimeZones
 
 function tostruct(T::Type, x::Any)
     try

--- a/src/ToStruct.jl
+++ b/src/ToStruct.jl
@@ -28,12 +28,12 @@ function tostruct(T::Union, x::Any)
     end
 end
 
-function tostruct(T::Type{U} where {U<:AbstractVector}, x::AbstractVector)
+function tostruct(T::Type{U} where U<:AbstractVector, x::AbstractVector)
     ET = eltype(T)
     T(collect(tostruct(ET, e) for e in x))
 end
 
-function tostruct(T::Type{U} where {U<:AbstractDict}, x::AbstractDict)
+function tostruct(T::Type{U} where U<:AbstractDict, x::AbstractDict)
     KT, VT = eltype(T()).types
     T(tostruct(KT, k) => tostruct(VT, v) for (k, v) in x)
 end

--- a/src/ToStruct.jl
+++ b/src/ToStruct.jl
@@ -5,7 +5,7 @@ function tostruct(T::Type, x::Any)
     try
         x::T
     catch
-# Kaeptenblaubaer: splicing in ".000" for avoiding parsing exception from ZonedDateTimes with missing microsenconds     
+# Kaeptenblaubaer: splicing in ".000" to avoid parsing exception from ZonedDateTimes with missing milliseconds     
         if isa(T, Type{ZonedDateTime}) && length(split(x, ".")) == 1
             ZonedDateTime(join(split(x, "+"), ".000+"))
         else

--- a/src/ToStruct.jl
+++ b/src/ToStruct.jl
@@ -5,8 +5,9 @@ function tostruct(T::Type, x::Any)
     try
         x::T
     catch
-        if isa(ZonedDateTime, T)
-            ZonedDateTime(join(split(x,"+"),".000+"))
+# Kaeptenblaubaer: splicing in ".000" for avoiding parsing exception from ZonedDateTimes with missing microsenconds     
+        if isa(T, Type{ZonedDateTime}) && length(split(x, ".")) == 1
+            ZonedDateTime(join(split(x, "+"), ".000+"))
         else
             try
                 convert(T, x)
@@ -27,12 +28,12 @@ function tostruct(T::Union, x::Any)
     end
 end
 
-function tostruct(T::Type{U} where U<:AbstractVector, x::AbstractVector)
+function tostruct(T::Type{U} where {U<:AbstractVector}, x::AbstractVector)
     ET = eltype(T)
     T(collect(tostruct(ET, e) for e in x))
 end
 
-function tostruct(T::Type{U} where U<:AbstractDict, x::AbstractDict)
+function tostruct(T::Type{U} where {U<:AbstractDict}, x::AbstractDict)
     KT, VT = eltype(T()).types
     T(tostruct(KT, k) => tostruct(VT, v) for (k, v) in x)
 end

--- a/src/ToStruct.jl
+++ b/src/ToStruct.jl
@@ -4,10 +4,14 @@ function tostruct(T::Type, x::Any)
     try
         x::T
     catch
-        try
-            convert(T, x)
-        catch
-            T(x)
+        if isa(ZonedDateTime, T)
+            ZonedDateTime(join(split(x,"+"),".000+"))
+        else
+            try
+                convert(T, x)
+            catch
+                T(x)
+            end
         end
     end
 end


### PR DESCRIPTION
splicing in ".000" to avoid parsing exception from ZonedDateTimes with missing milliseconds.
LibPQ, for instance, returns such strings for postgres timestamptz fields